### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -31,6 +31,59 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/participants?email=student@mergington.edu` | Unregister a participant from an activity                           |
+
+### Example: Sign Up a Student
+
+Request:
+
+```
+POST /activities/Chess%20Club/signup?email=alex@mergington.edu
+```
+
+curl:
+
+```bash
+curl -X POST "http://localhost:8000/activities/Chess%20Club/signup?email=alex@mergington.edu"
+```
+
+Response:
+
+```json
+{
+   "message": "Signed up alex@mergington.edu for Chess Club"
+}
+```
+
+### Example: Unregister a Student
+
+Request:
+
+```
+DELETE /activities/Chess%20Club/participants?email=alex@mergington.edu
+```
+
+curl:
+
+```bash
+curl -X DELETE "http://localhost:8000/activities/Chess%20Club/participants?email=alex@mergington.edu"
+```
+
+Response:
+
+```json
+{
+   "message": "Unregistered alex@mergington.edu from Chess Club"
+}
+```
+
+## Run Tests
+
+Run the backend test suite with:
+
+```
+python -m pytest -q
+```
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,42 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "Soccer Team": {
+        "description": "Team practices, drills, and inter-school soccer matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Basketball fundamentals, scrimmages, and friendly competitions",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore drawing, painting, and mixed-media art projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["isabella@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting workshops, improvisation, and school stage performances",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Practice public speaking, argumentation, and competitive debate",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Math Olympiad": {
+        "description": "Advanced problem-solving practice for math competitions",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["evelyn@mergington.edu", "abigail@mergington.edu"]
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -62,6 +98,9 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+# Validate student is not already signed up    if email in activity["participants"]:
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -98,9 +98,25 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
-# Validate student is not already signed up    if email in activity["participants"]:
+    # Validate student is not already signed up
     if email in activity["participants"]:
         raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,11 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,37 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants.length
+          ? `<ul class="participants-list">${details.participants
+              .map(
+                (participant) => `
+                  <li>
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="participant-delete-button"
+                      data-activity="${name}"
+                      data-email="${participant}"
+                      aria-label="Unregister ${participant} from ${name}"
+                      title="Unregister"
+                    >
+                      🗑️
+                    </button>
+                  </li>
+                `
+              )
+              .join("")}</ul>`
+          : '<p class="participants-empty">No participants yet</p>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Participants</p>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -34,6 +60,49 @@ document.addEventListener("DOMContentLoaded", () => {
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
+      });
+
+      const deleteButtons = activitiesList.querySelectorAll(".participant-delete-button");
+      deleteButtons.forEach((button) => {
+        button.addEventListener("click", async () => {
+          const activity = button.dataset.activity;
+          const email = button.dataset.email;
+
+          if (!activity || !email) {
+            return;
+          }
+
+          try {
+            const response = await fetch(
+              `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+              {
+                method: "DELETE",
+              }
+            );
+
+            const result = await response.json();
+
+            if (response.ok) {
+              messageDiv.textContent = result.message;
+              messageDiv.className = "success";
+              await fetchActivities();
+            } else {
+              messageDiv.textContent = result.detail || "Failed to unregister participant";
+              messageDiv.className = "error";
+            }
+
+            messageDiv.classList.remove("hidden");
+
+            setTimeout(() => {
+              messageDiv.classList.add("hidden");
+            }, 5000);
+          } catch (error) {
+            messageDiv.textContent = "Failed to unregister participant. Please try again.";
+            messageDiv.className = "error";
+            messageDiv.classList.remove("hidden");
+            console.error("Error unregistering participant:", error);
+          }
+        });
       });
     } catch (error) {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
@@ -62,6 +131,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,60 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #d8def8;
+  border-radius: 6px;
+  background-color: #f3f6ff;
+}
+
+.participants-title {
+  font-weight: bold;
+  color: #1a237e;
+  margin-bottom: 8px;
+}
+
+.participants-list {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+  color: #243a5e;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background-color: #ffffff;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.participant-delete-button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px;
+}
+
+.participant-delete-button:hover {
+  transform: scale(1.1);
+}
+
+.participants-empty {
+  font-style: italic;
+  color: #5f6f8c;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(deepcopy(original_activities))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,107 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    endpoint = "/"
+
+    # Act
+    response = client.get(endpoint, follow_redirects=False)
+
+    # Assert
+    assert response.status_code in (302, 307)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_all_activities(client):
+    # Arrange
+    endpoint = "/activities"
+
+    # Act
+    response = client.get(endpoint)
+    data = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(data, dict)
+    assert "Chess Club" in data
+    assert "participants" in data["Chess Club"]
+
+
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+
+    # Assert
+    assert response.status_code == 200
+    assert email in participants
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_rejects_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "someone@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregistration_removes_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants", params={"email": email})
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in participants
+
+
+def test_unregistration_rejects_unknown_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "ghost@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"
+
+
+def test_unregistration_rejects_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"


### PR DESCRIPTION
This pull request adds the ability for students to unregister from activities, improves the frontend to support participant management, documents the new API, and introduces automated backend tests. The most significant changes are grouped below:

**Backend API Enhancements:**

* Added a new `DELETE /activities/{activity_name}/participants?email=...` endpoint to allow students to unregister from activities, with appropriate error handling for unknown activities or participants.
* Improved the `POST /activities/{activity_name}/signup` endpoint to prevent duplicate signups by checking if a student is already registered.
* Expanded the in-memory `activities` database with additional sample activities and participants for more comprehensive data.

**Frontend Improvements:**

* Updated the frontend to display a list of participants for each activity, and added an "unregister" (delete) button next to each participant, allowing users to remove participants via the new API endpoint. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R53) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R64-R106)
* Refreshed the activities list after sign-up or unregistration actions to keep the UI in sync with the backend.

**Styling Updates:**

* Introduced new CSS styles for the participants section, including layout, button styles, and empty state messaging.

**Documentation:**

* Updated the `README.md` to document the new unregister API endpoint, provide example requests/responses, and add instructions for running backend tests.

**Testing:**

* Added a comprehensive backend test suite (`tests/test_app.py`) covering activity retrieval, participant sign-up (including error cases), and unregistration. Also included a fixture to reset the in-memory activities state between tests for isolation. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R1-R107) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R19)